### PR TITLE
Introduced lightweight editor to the project

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kestra",
       "version": "0.1.0",
       "dependencies": {
+        "@guolao/vue-monaco-editor": "^1.5.1",
         "@kestra-io/ui-libs": "^0.0.37",
         "@popperjs/core": "npm:@sxzz/popperjs-es@2.11.7",
         "@vue-flow/background": "^1.2.0",
@@ -69,6 +70,7 @@
         "monaco-editor": "0.39.0",
         "monaco-yaml": "4.0.0-alpha.0",
         "prettier": "^3.2.5",
+        "rollup": "^4.12.1",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-visualizer": "^5.12.0",
         "sass": "^1.71.1",
@@ -203,6 +205,50 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.3.tgz",
       "integrity": "sha512-uvnFKtPgzLnpzzTRfhDlvXX0kLYi9lDRQbcDmT8iXl71Rx+uwSuaUIQl3DNC7w5OweAQ7XQMDObML+KaYDQfng=="
     },
+    "node_modules/@guolao/vue-monaco-editor": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@guolao/vue-monaco-editor/-/vue-monaco-editor-1.5.1.tgz",
+      "integrity": "sha512-nhbQHDAwsxrdH/yitcrBgAkN8Cae0IEiYe/M3LWK8bSJRfapkbMyfTHE6Gcxsxa/6efSUZAPDo8dJWBDx5GZyA==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.4.0",
+        "vue-demi": "latest"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.7.1",
+        "monaco-editor": ">=0.43.0",
+        "vue": "^2.6.14 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@guolao/vue-monaco-editor/node_modules/vue-demi": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
+      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -316,6 +362,17 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
+      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -432,10 +489,106 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.1.tgz",
+      "integrity": "sha512-iU2Sya8hNn1LhsYyf0N+L4Gf9Qc+9eBTJJJsaOGUp+7x4n2M9dxTt8UvhJl3oeftSjblSlpCfvjA/IfP3g5VjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.1.tgz",
+      "integrity": "sha512-wlzcWiH2Ir7rdMELxFE5vuM7D6TsOcJ2Yw0c3vaBR3VOsJFVTx9xvwnAvhgU5Ii8Gd6+I11qNHwndDscIm0HXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.1.tgz",
+      "integrity": "sha512-YRXa1+aZIFN5BaImK+84B3uNK8C6+ynKLPgvn29X9s0LTVCByp54TB7tdSMHDR7GTV39bz1lOmlLDuedgTwwHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.1.tgz",
+      "integrity": "sha512-opjWJ4MevxeA8FhlngQWPBOvVWYNPFkq6/25rGgG+KOy0r8clYwL1CFd+PGwRqqMFVQ4/Qd3sQu5t7ucP7C/Uw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.1.tgz",
+      "integrity": "sha512-uBkwaI+gBUlIe+EfbNnY5xNyXuhZbDSx2nzzW8tRMjUmpScd6lCQYKY2V9BATHtv5Ef2OBq6SChEP8h+/cxifQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.1.tgz",
+      "integrity": "sha512-0bK9aG1kIg0Su7OcFTlexkVeNZ5IzEsnz1ept87a0TUgZ6HplSgkJAnFpEVRW7GRcikT4GlPV0pbtVedOaXHQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.1.tgz",
+      "integrity": "sha512-qB6AFRXuP8bdkBI4D7UPUbE7OQf7u5OL+R94JE42Z2Qjmyj74FtDdLGeriRyBDhm4rQSvqAGCGC01b8Fu2LthQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.1.tgz",
+      "integrity": "sha512-sHig3LaGlpNgDj5o8uPEoGs98RII8HpNIqFtAI8/pYABO8i0nb1QzT0JDoXF/pxzqO+FkxvwkHZo9k0NJYDedg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.7.0.tgz",
-      "integrity": "sha512-cCkoGlGWfBobdDtiiypxf79q6k3/iRVGu1HVLbD92gWV5WZbmuWJCgRM4x2N6i7ljGn1cGytPn9ZAfS8UwF6vg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.1.tgz",
+      "integrity": "sha512-nD3YcUv6jBJbBNFvSbp0IV66+ba/1teuBcu+fBBPZ33sidxitc6ErhON3JNavaH8HlswhWMC3s5rgZpM4MtPqQ==",
       "cpu": [
         "x64"
       ],
@@ -445,15 +598,51 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.7.0.tgz",
-      "integrity": "sha512-R2oBf2p/Arc1m+tWmiWbpHBjEcJnHVnv6bsypu4tcKdrYTpDfl1UT9qTyfkIL1iiii5D4WHxUHCg5X0pzqmxFg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.1.tgz",
+      "integrity": "sha512-7/XVZqgBby2qp/cO0TQ8uJK+9xnSdJ9ct6gSDdEr4MfABrjTyrW6Bau7HQ73a2a5tPB7hno49A0y1jhWGDN9OQ==",
       "cpu": [
         "x64"
       ],
       "optional": true,
       "os": [
         "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.1.tgz",
+      "integrity": "sha512-CYc64bnICG42UPL7TrhIwsJW4QcKkIt9gGlj21gq3VV0LL6XNb1yAdHVp1pIi9gkts9gGcT3OfUYHjGP7ETAiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.1.tgz",
+      "integrity": "sha512-LN+vnlZ9g0qlHGlS920GR4zFCqAwbv2lULrR29yGaWP9u7wF5L7GqWu9Ah6/kFZPXPUkpdZwd//TNR+9XC9hvA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.1.tgz",
+      "integrity": "sha512-n+vkrSyphvmU0qkQ6QBNXCGr2mKjhP08mPRM/Xp5Ck2FV4NrHU+y6axzDeixUrCBHVUS51TZhjqrKBBsHLKb2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -3685,8 +3874,7 @@
     "node_modules/monaco-editor": {
       "version": "0.39.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.39.0.tgz",
-      "integrity": "sha512-zhbZ2Nx93tLR8aJmL2zI1mhJpsl87HMebNBM6R8z4pLfs8pj604pIVIVwyF1TivcfNtIPpMXL+nb3DsBmE/x6Q==",
-      "dev": true
+      "integrity": "sha512-zhbZ2Nx93tLR8aJmL2zI1mhJpsl87HMebNBM6R8z4pLfs8pj604pIVIVwyF1TivcfNtIPpMXL+nb3DsBmE/x6Q=="
     },
     "node_modules/monaco-yaml": {
       "version": "4.0.0-alpha.0",
@@ -4382,9 +4570,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.7.0.tgz",
-      "integrity": "sha512-7Kw0dUP4BWH78zaZCqF1rPyQ8D5DSU6URG45v1dqS/faNsx9WXyess00uTOZxKr7oR/4TOjO1CPudT8L1UsEgw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.1.tgz",
+      "integrity": "sha512-ggqQKvx/PsB0FaWXhIvVkSWh7a/PCLQAsMjBc+nA2M8Rv2/HG0X6zvixAB7KyZBRtifBUhy5k8voQX/mRnABPg==",
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -4393,19 +4584,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.7.0",
-        "@rollup/rollup-android-arm64": "4.7.0",
-        "@rollup/rollup-darwin-arm64": "4.7.0",
-        "@rollup/rollup-darwin-x64": "4.7.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.7.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.7.0",
-        "@rollup/rollup-linux-arm64-musl": "4.7.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.7.0",
-        "@rollup/rollup-linux-x64-gnu": "4.7.0",
-        "@rollup/rollup-linux-x64-musl": "4.7.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.7.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.7.0",
-        "@rollup/rollup-win32-x64-msvc": "4.7.0",
+        "@rollup/rollup-android-arm-eabi": "4.12.1",
+        "@rollup/rollup-android-arm64": "4.12.1",
+        "@rollup/rollup-darwin-arm64": "4.12.1",
+        "@rollup/rollup-darwin-x64": "4.12.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.12.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.12.1",
+        "@rollup/rollup-linux-arm64-musl": "4.12.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.12.1",
+        "@rollup/rollup-linux-x64-gnu": "4.12.1",
+        "@rollup/rollup-linux-x64-musl": "4.12.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.12.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.12.1",
+        "@rollup/rollup-win32-x64-msvc": "4.12.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -4804,6 +4995,11 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/std-env": {
       "version": "3.6.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix"
   },
   "dependencies": {
+    "@guolao/vue-monaco-editor": "^1.5.1",
     "@kestra-io/ui-libs": "^0.0.37",
     "@popperjs/core": "npm:@sxzz/popperjs-es@2.11.7",
     "@vue-flow/background": "^1.2.0",
@@ -73,6 +74,7 @@
     "monaco-editor": "0.39.0",
     "monaco-yaml": "4.0.0-alpha.0",
     "prettier": "^3.2.5",
+    "rollup": "^4.12.1",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-visualizer": "^5.12.0",
     "sass": "^1.71.1",

--- a/ui/src/components/namespace/LightEditor.vue
+++ b/ui/src/components/namespace/LightEditor.vue
@@ -1,0 +1,514 @@
+<template>
+    <div>
+        <top-nav-bar :title="routeInfo.title">
+            <template #additional-right>
+                <namespace-select
+                    class="fit-content"
+                    data-type="flow"
+                    :value="namespace"
+                    @update:model-value="namespaceUpdate"
+                    allow-create
+                    :is-filter="false"
+                />
+
+                <el-dropdown>
+                    <el-button :icon="Plus" class="p-2 m-0" />
+                    <template #dropdown>
+                        <el-dropdown-menu>
+                            <el-dropdown-item :icon="FilePlus" @click="pickFile">
+                                <input
+                                    ref="filePicker"
+                                    type="file"
+                                    multiple
+                                    style="display: none"
+                                    @change="importFiles"
+                                >
+                                {{ $t("namespace files.import.file") }}
+                            </el-dropdown-item>
+                            <el-dropdown-item :icon="FolderPlus" @click="pickFolder">
+                                <input
+                                    ref="folderPicker"
+                                    type="file"
+                                    webkitdirectory
+                                    mozdirectory
+                                    msdirectory
+                                    odirectory
+                                    directory
+                                    style="display: none"
+                                    @change="importNSFiles"
+                                >
+                                {{ $t("namespace files.import.folder") }}
+                            </el-dropdown-item>
+                        </el-dropdown-menu>
+                    </template>
+                </el-dropdown>
+                <el-tooltip :hide-after="50" :content="$t('namespace files.export')">
+                    <el-button :icon="FolderZip" class="p-2 m-0" @click="exportNsFiles" />
+                </el-tooltip>
+                <trigger-flow
+                    ref="triggerFlow"
+                    :disabled="!flow"
+                    :flow-id="flow"
+                    :namespace="namespace"
+                />
+            </template>
+        </top-nav-bar>
+        <div v-if="namespace" class="wrapper">
+            <div class="sidebar">
+                <div class="button">
+                    <el-button type="primary" @click="fileDialog.visible = true">
+                        Add File
+                    </el-button>
+                </div>
+                <el-tree
+                    :data="explorerFiles"
+                    :expand-on-click-node="false"
+                    @node-click="nodeClick"
+                    empty-text="No Files"
+                    class="sidebar"
+                >
+                    <template #default="{data}">
+                        <el-row
+                            class="row-bg"
+                            justify="space-between"
+                            :class="{opened: openedTabsNames.includes(data.label)}"
+                        >
+                            <el-col :span="6">
+                                <span>
+                                    {{ data.label }}
+                                </span>
+                            </el-col>
+                            <el-col :span="6" class="remove-button">
+                                <el-icon
+                                    size="small"
+                                    @click.stop="handleFileRemove(data.label)"
+                                >
+                                    <Delete />
+                                </el-icon>
+                            </el-col>
+                        </el-row>
+                    </template>
+                </el-tree>
+            </div>
+            <el-tabs v-model="currentTab">
+                <el-tab-pane
+                    v-for="(tab, index) in openedTabs"
+                    :key="index"
+                    :name="index"
+                    :label="tab.name"
+                >
+                    <template #label>
+                        <el-text class="px-3">
+                            {{ tab.name }}
+                        </el-text>
+                        <el-icon
+                            size="large"
+                            color="primary"
+                            @click="handleTabClose(tab.name, index)"
+                        >
+                            <Close />
+                        </el-icon>
+                    </template>
+                    <vue-monaco-editor
+                        v-model:value="tab.content"
+                        :options="EDITOR_OPTIONS"
+                        :language="tab.language"
+                        :theme="theme"
+                    />
+                </el-tab-pane>
+            </el-tabs>
+
+            <el-dialog
+                v-model="fileDialog.visible"
+                title="Add New File"
+                width="500"
+                @open-auto-focus="focusInputRef"
+            >
+                <el-input
+                    ref="inputRef"
+                    v-model="fileDialog.name"
+                    placeholder="Name"
+                    size="large"
+                    class="mb-3"
+                />
+                <el-select
+                    v-model="fileDialog.extension"
+                    placeholder="Select"
+                    size="large"
+                    class="mb-3"
+                >
+                    <el-option
+                        v-for="extension in extensions"
+                        :key="extension.value"
+                        :value="extension.value"
+                        :label="extension.label"
+                    />
+                </el-select>
+                <template #footer>
+                    <div>
+                        <el-button @click="fileDialog.visible = false">
+                            Cancel
+                        </el-button>
+                        <el-button
+                            type="primary"
+                            :disabled="!fileDialog.name || !fileDialog.extension"
+                            @click="addFile"
+                        >
+                            Add File
+                        </el-button>
+                    </div>
+                </template>
+            </el-dialog>
+        </div>
+        <section v-else class="container">
+            <el-alert type="info" :closable="false">
+                {{ $t("namespace choice") }}
+            </el-alert>
+        </section>
+    </div>
+</template>
+
+<script setup>
+    import {onUnmounted, watchEffect, nextTick, ref, computed} from "vue";
+
+    import {useMonaco} from "@guolao/vue-monaco-editor";
+
+    import NamespaceSelect from "./NamespaceSelect.vue";
+    import TopNavBar from "../layout/TopNavBar.vue";
+    import TriggerFlow from "../flows/TriggerFlow.vue";
+
+    import Plus from "vue-material-design-icons/Plus.vue";
+    import FolderPlus from "vue-material-design-icons/FolderPlus.vue";
+    import FilePlus from "vue-material-design-icons/FilePlus.vue";
+    import FolderZip from "vue-material-design-icons/FolderZip.vue";
+    import Close from "vue-material-design-icons/Close.vue";
+    import Delete from "vue-material-design-icons/Delete.vue";
+
+    import {useI18n} from "vue-i18n";
+    const {t} = useI18n();
+
+    import {useToast} from "./composables/toast.js";
+    const {success, error} = useToast();
+
+    const EDITOR_OPTIONS = {
+        automaticLayout: true,
+        minimap: {enabled: false},
+        formatOnType: true,
+        formatOnPaste: true,
+    };
+
+    const containerRef = ref();
+    const {monacoRef, unload} = useMonaco();
+
+    const stop = watchEffect(() => {
+        if (monacoRef.value && containerRef.value) {
+            nextTick(() => stop());
+            monacoRef.value.editor.create(containerRef.value, {});
+        }
+    });
+
+    onUnmounted(() => !monacoRef.value && unload());
+
+    const importedFiles = ref([]);
+    const explorerFiles = computed(() =>
+        importedFiles.value.map((file) => ({
+            label: file.name,
+            extension: file.extension,
+            content: file.content,
+        }))
+    );
+    const readFile = (file) => {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result);
+            reader.onerror = reject;
+            reader.readAsText(file);
+        });
+    };
+    const importFiles = async (event) => {
+        const files = [...event.target.files];
+
+        try {
+            for (const file of files) {
+                const content = await readFile(file);
+                importedFiles.value.push({
+                    name: file.name,
+                    extension: file.name.split(".").pop(),
+                    content: content,
+                });
+            }
+            success(t("namespace files.import.success"));
+        } catch (_error) {
+            error(t("namespace files.import.error"));
+        } finally {
+            event.target.value = "";
+        }
+    };
+
+    const inputRef = ref();
+    const focusInputRef = () => nextTick(() => inputRef.value.focus());
+    const fileDialog = ref({visible: false, name: "", extension: ""});
+    const extensions = [
+        {label: "JavaScript", value: "js"},
+        {label: "YAML", value: "yaml"},
+    ];
+    const addFile = () => {
+        const {name, extension} = fileDialog.value;
+        const content = `// Initial content of your ${name}.${extension} file`;
+
+        importedFiles.value.push({
+            name: `${name}.${extension}`,
+            extension,
+            content,
+        });
+        fileDialog.value = {visible: false, name: "", extension: ""};
+    };
+
+    const nodeClick = (node) => {
+        const getLanguage = (extension) =>
+            extension === "js" ? "javascript" : extension;
+
+        if (openedTabs.value.find((tab) => tab.name === node.label)) {
+            currentTab.value = openedTabs.value.findIndex(
+                (tab) => tab.name === node.label
+            );
+            return;
+        }
+
+        openedTabs.value.push({
+            name: node.label,
+            language: getLanguage(node.extension),
+            content: node.content,
+        });
+
+        currentTab.value = openedTabs.value.findIndex(
+            (tab) => tab.name === node.label
+        );
+    };
+    const handleFileRemove = (name) => {
+        openedTabs.value = openedTabs.value.filter((tab) => tab.name !== name);
+        importedFiles.value = importedFiles.value.filter(
+            (file) => file.name !== name
+        );
+    };
+
+    const openedTabs = ref([]);
+    const openedTabsNames = computed(() => openedTabs.value.map((tab) => tab.name));
+    const currentTab = ref(0);
+    const handleTabClose = (name, index) => {
+        openedTabs.value = openedTabs.value.filter((tab) => tab.name !== name);
+    };
+</script>
+
+<style lang="scss">
+.wrapper {
+  display: flex;
+  height: calc(100vh - 64.8px);
+}
+
+.sidebar {
+  width: 260px;
+  overflow: auto;
+  background-color: var(--card-bg);
+  border-right: 1px solid var(--border-color);
+
+  .button {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 20px;
+
+    & button {
+      width: 100%;
+    }
+  }
+
+  .el-tree {
+    --el-tree-node-hover-bg-color: var(--el-color-primary-light-8);
+
+    & .el-tree-node {
+      height: 34px;
+
+      & .el-tree-node__content {
+        height: 34px;
+
+        & .el-row {
+          width: 100%;
+
+          &.opened {
+            color: var(--el-color-primary);
+          }
+
+          & .remove-button {
+            color: var(--el-color-primary);
+            padding-right: 16px;
+            text-align: right;
+          }
+        }
+      }
+    }
+  }
+}
+
+.el-tabs {
+  width: 1px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  .el-tabs__content {
+    flex: 1;
+
+    .el-tab-pane {
+      height: 100%;
+    }
+  }
+}
+</style>
+
+<script>
+    import RouteContext from "../../mixins/routeContext";
+    import RestoreUrl from "../../mixins/restoreUrl";
+    import {apiUrl} from "override/utils/route";
+    import {mapState} from "vuex";
+    import {storageKeys} from "../../utils/constants";
+
+    export default {
+        mixins: [RouteContext, RestoreUrl],
+        methods: {
+            importNsFiles(event) {
+                const files = [...event.target.files];
+                Promise.all(
+                    files.map((file) => {
+                        return this.$store.dispatch("namespace/importFile", {
+                            namespace: this.namespace,
+                            file: file,
+                        });
+                    })
+                )
+                    .then(() => {
+                        this.$message({
+                            message: this.$t("namespace files.import.success"),
+                            type: "success",
+                        });
+                    })
+                    .catch(() => {
+                        this.$message({
+                            message: this.$t("namespace files.import.error"),
+                            type: "error",
+                        });
+                    })
+                    .finally(() => {
+                        // this.$refs.vscodeIde.contentDocument.location.reload(true);
+                        console.log("dsf");
+                        event.target.value = "";
+                    });
+            },
+            exportNsFiles() {
+                this.$store.dispatch("namespace/exportFiles", {
+                    namespace: this.namespace,
+                });
+            },
+            pickFile() {
+                this.$refs.filePicker.click();
+            },
+            pickFolder() {
+                this.$refs.folderPicker.click();
+            },
+            namespaceUpdate(namespace) {
+                localStorage.setItem(storageKeys.LATEST_NAMESPACE, namespace);
+                this.$router.push({
+                    params: {
+                        namespace,
+                    },
+                });
+            },
+            handleTabsDirty(tabs) {
+                // Add tabs not saved
+                this.tabsNotSaved = this.tabsNotSaved.concat(tabs.dirty);
+                // Removed tabs closed
+                this.tabsNotSaved = this.tabsNotSaved.filter(
+                    (e) => !tabs.closed.includes(e)
+                );
+                this.$store.dispatch("core/isUnsaved", this.tabsNotSaved.length > 0);
+            },
+        },
+        data() {
+            return {
+                flow: null,
+                tabsNotSaved: [],
+                uploadFileName: undefined,
+            };
+        },
+        mounted() {
+            window.addEventListener("message", (event) => {
+                const message = event.data;
+                if (message.type === "kestra.tabFileChanged") {
+                    const flowsFolderPath = `/${this.namespace}/_flows/`;
+                    const filePath = message.filePath.path;
+                    if (filePath.startsWith(flowsFolderPath)) {
+                        const fileName = filePath.split(flowsFolderPath)[1];
+                        // trim the eventual extension
+                        this.flow = fileName.split(".")[0];
+                    } else {
+                        this.flow = undefined;
+                    }
+                } else if (message.type === "kestra.tabsChanged") {
+                    this.handleTabsDirty(message.tabs);
+                } else if (message.type === "kestra.flowSaved") {
+                    this.$refs.triggerFlow.loadDefinition();
+                }
+            });
+
+            // Setup namespace
+            const namespace = localStorage.getItem(storageKeys.LATEST_NAMESPACE)
+                ? localStorage.getItem(storageKeys.LATEST_NAMESPACE)
+                : localStorage.getItem(storageKeys.DEFAULT_NAMESPACE);
+            if (namespace) {
+                this.namespaceUpdate(namespace);
+            } else if (this.namespaces?.length > 0) {
+                this.namespaceUpdate(this.namespaces[0]);
+            } else if (localStorage.getItem("tourDoneOrSkip") !== "true") {
+                this.$router.push({
+                    name: "flows/create",
+                    params: {
+                        tenant: this.$route.params.tenant,
+                    },
+                });
+            }
+        },
+        computed: {
+            ...mapState("namespace", ["namespaces"]),
+            routeInfo() {
+                return {
+                    title: this.$t("editor"),
+                };
+            },
+            theme() {
+                const current = localStorage.getItem("theme");
+                if (!current) return "vs";
+
+                return current === "light" ? "vs" : "vs-dark";
+            },
+            vscodeIndexUrl() {
+                const uiSubpath = KESTRA_UI_PATH === "./" ? "/" : KESTRA_UI_PATH;
+                return `${uiSubpath}vscode.html?KESTRA_UI_PATH=${uiSubpath}&KESTRA_API_URL=${apiUrl(
+                    this.$store
+                )}&THEME=${this.theme}&namespace=${this.namespace}`;
+            },
+            namespace() {
+                return this.$route.params.namespace;
+            },
+        },
+    };
+</script>
+
+<style lang="scss">
+.fit-content {
+  width: fit-content;
+}
+.vscode-editor {
+  height: calc(100vh - 64.8px) !important;
+  width: 100%;
+}
+</style>

--- a/ui/src/components/namespace/LightEditor.vue
+++ b/ui/src/components/namespace/LightEditor.vue
@@ -248,6 +248,7 @@
     const inputRef = ref();
     const focusInputRef = () => nextTick(() => inputRef.value.focus());
     const fileDialog = ref({visible: false, name: "", extension: ""});
+    const getLanguage = (extension) => extension === "js" ? "javascript" : extension;
     const extensions = [
         {label: "JavaScript", value: "js"},
         {label: "YAML", value: "yaml"},
@@ -262,12 +263,18 @@
             content,
         });
         fileDialog.value = {visible: false, name: "", extension: ""};
+
+        nextTick(() => {
+            openedTabs.value.push({
+                name: `${name}.${extension}`,
+                language: getLanguage(extension),
+                content: content,
+            });
+            currentTab.value = openedTabs.value.length - 1;
+        });
     };
 
     const nodeClick = (node) => {
-        const getLanguage = (extension) =>
-            extension === "js" ? "javascript" : extension;
-
         if (openedTabs.value.find((tab) => tab.name === node.label)) {
             currentTab.value = openedTabs.value.findIndex(
                 (tab) => tab.name === node.label

--- a/ui/src/components/namespace/composables/toast.js
+++ b/ui/src/components/namespace/composables/toast.js
@@ -1,0 +1,109 @@
+import {ElNotification, ElMessageBox, ElTable, ElTableColumn} from "element-plus";
+import {h} from "vue";
+
+export function useToast() {
+  const _wrap = function (message) {
+    if (Array.isArray(message) && message.length > 0) {
+      return h(
+        ElTable,
+        {
+          stripe: true,
+          tableLayout: "auto",
+          fixed: true,
+          data: message,
+          class: ["mt-2"],
+          size: "small",
+        },
+        [h(ElTableColumn, {label: "Message", formatter: (row) => h("span", {innerHTML: row.message})})]
+      );
+    } else {
+      return h("span", {innerHTML: message});
+    }
+  };
+
+  const confirm = function (message, callback) {
+    ElMessageBox.confirm(
+      _wrap(message || "Confirmation"),
+      "Confirmation",
+      {
+        type: "warning",
+      }
+    )
+      .then(() => {
+        callback();
+      });
+  };
+
+  const saved = function (name, title, options) {
+    ElNotification.closeAll();
+    const message = options?.multiple ? `Multiple items saved: ${name}` : `Item saved: ${name}`;
+    ElNotification({
+      ...{
+        title: title || "Saved",
+        message: _wrap(message),
+        position: "bottom-right",
+        type: "success",
+      },
+      ...(options || {})
+    });
+  };
+
+  const deleted = function (name, title, options) {
+    ElNotification({
+      ...{
+        title: title || "Deleted",
+        message: _wrap(`Deleted confirmation: ${name}`),
+        position: "bottom-right",
+        type: "success",
+      },
+      ...(options || {})
+    });
+  };
+
+  const success = function (message, title, options) {
+    ElNotification({
+      ...{
+        title: title || "Success",
+        message: _wrap(message),
+        position: "bottom-right",
+        type: "success",
+      },
+      ...(options || {})
+    });
+  };
+
+  const warning = function (message, title, options) {
+    ElNotification({
+      ...{
+        title: title || "Warning",
+        message: _wrap(message),
+        position: "bottom-right",
+        type: "warning",
+      },
+      ...(options || {})
+    });
+  };
+
+  const error = function (message, title, options) {
+    ElNotification({
+      ...{
+        title: title || "Error",
+        message: _wrap(message),
+        position: "bottom-right",
+        type: "error",
+        duration: 0,
+        customClass: "large"
+      },
+      ...(options || {})
+    });
+  };
+
+  return {
+    confirm,
+    saved,
+    deleted,
+    success,
+    warning,
+    error
+  };
+}

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -1,6 +1,8 @@
 import {createApp} from "vue"
 import VueAxios from "vue-axios";
 
+import {install as VueMonacoEditorPlugin} from "@guolao/vue-monaco-editor"
+
 import App from "./App.vue"
 import initApp from "./utils/init"
 import configureAxios from "./utils/axios"
@@ -10,6 +12,12 @@ import stores from "./stores/store";
 
 const app = createApp(App)
 const {store, router} = initApp(app, routes, stores, translations);
+
+app.use(VueMonacoEditorPlugin, {
+    paths: {
+      vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs"
+    },
+  })
 
 // axios
 configureAxios((instance) => {

--- a/ui/src/override/components/LeftMenu.vue
+++ b/ui/src/override/components/LeftMenu.vue
@@ -124,6 +124,14 @@
                         },
                     },
                     {
+                        href: {name: "lighteditor"},
+                        title: this.$t("lighteditor"),
+                        icon: {
+                            element: shallowRef(FolderEditOutline),
+                            class: "menu-icon",
+                        },
+                    },
+                    {
                         href: {name: "templates/list"},
                         routes: this.routeStartWith("templates"),
                         title: this.$t("templates"),

--- a/ui/src/routes/routes.js
+++ b/ui/src/routes/routes.js
@@ -18,6 +18,7 @@ import BlueprintDetail from "../components/flows/blueprints/BlueprintDetail.vue"
 import Triggers from "../components/admin/Triggers.vue";
 import Workers from "../components/admin/Workers.vue";
 import Editor from "../components/namespace/Editor.vue";
+import LightEditor from "../components/namespace/LightEditor.vue";
 import Stats from "override/components/admin/stats/Stats.vue";
 
 
@@ -30,6 +31,7 @@ export default [
 
     //Namespace file editor
     {name: "editor", path: "/:tenant?/editor/:namespace?", component: Editor},
+    {name: "lighteditor", path: "/:tenant?/lighteditor/:namespace?", component: LightEditor},
 
     //Flows
     {name: "flows/list", path: "/:tenant?/flows", component: Flows},

--- a/ui/src/translations.json
+++ b/ui/src/translations.json
@@ -496,6 +496,7 @@
     "source and doc": "Source and documentation",
     "source and blueprints": "Source and blueprints",
     "editor": "Editor",
+    "lighteditor": "Light Editor",
     "error in editor": "An error have been found in the editor",
     "delete task confirm": "Do you want to delete the task <code>{taskId}</code>?",
     "can not save": "Can not save",


### PR DESCRIPTION
This PR aims to introduce new, lightweight version of `Monaco` editor to the project.

How can this be checked?

- Checkout the `light-editor` branch and run `npm i --force` from `ui` folder.
- Start the development server with the command `npm run dev`.
- There is a `Light Editor` menu item on the left side menu
- When opened, click on `plus` icon in the top menu and choose couple of files from the picker
- You'll be able to see all the files in a `Tree View` on the left, and open them in editor

What needs to be improved?
- [ ] Decide which file types to support and limit loading of those files only (now it will work for `*.js` and `*.yaml` types.
- [ ] Better handling of the editor tabs closing (decide on the desired behaviour).
- [ ] Better handling of the editor tabs after file deletion.
- [x] Opening newly created file after creation.

Video demonstration of the feature:
https://github.com/MilosPaunovic/kestra/assets/62475782/e765f33b-0c36-4508-a0a8-93eec7fc94dd